### PR TITLE
feat: Allow overriding Nginx configuration via values.yaml

### DIFF
--- a/charts/jumpserver/templates/celery/deployment-celery.yaml
+++ b/charts/jumpserver/templates/celery/deployment-celery.yaml
@@ -41,11 +41,19 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "jumpserver.serviceAccountName" $ }}
       securityContext:
+        {{- if hasKey $.Values.celery "podSecurityContext" }}
+        {{- toYaml $.Values.celery.podSecurityContext | nindent 8 }}
+        {{- else }}
         {{- toYaml .podSecurityContext | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ $containerName }}
           securityContext:
+            {{- if hasKey $.Values.celery "securityContext" }}
+            {{- toYaml $.Values.celery.securityContext | nindent 12 }}
+            {{- else }}
             {{- toYaml .securityContext | nindent 12 }}
+            {{- end }}
           image: {{ $imageWithTag }}
           imagePullPolicy: {{ .image.pullPolicy | quote }}
           args: ["start", "task"]

--- a/charts/jumpserver/templates/web/configmap-web.yaml
+++ b/charts/jumpserver/templates/web/configmap-web.yaml
@@ -10,7 +10,14 @@ metadata:
     {{- include "jumpserver.labels" $ | nindent 4 }}
     {{- toYaml .labels | nindent 4 }}
 data:
-{{- $path := printf "%s/%s/%s" "configs" "jms-web" "default.conf" -}}
-{{- tpl (( $.Files.Glob $path ).AsConfig) $ | nindent 2 }}
+  default.conf: |
+    {{- $nginxConfigContent := "" }}
+    {{- if .nginxConfig }}
+      {{- $nginxConfigContent = .nginxConfig }}
+    {{- else }}
+      {{- $path := printf "%s/%s/%s" "configs" "jms-web" "default.conf" -}}
+      {{- $nginxConfigContent = $.Files.Get $path }}
+    {{- end }}
+    {{- tpl $nginxConfigContent $ | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/jumpserver/values.yaml
+++ b/charts/jumpserver/values.yaml
@@ -158,6 +158,21 @@ core:
 
   affinity: {}
 
+celery:
+  ## Celery configuration
+  ## Celery is the task queue worker for JumpServer core
+  ## If not specified, it will inherit the configuration from core
+  # podSecurityContext: {}
+    # fsGroup: 2000
+  securityContext:
+    privileged: true
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
 koko:
   enabled: true
 


### PR DESCRIPTION
Introduces `web.nginxConfig` in `values.yaml` to allow users to provide a custom `default.conf` for the jms-web service. The new value is rendered with `tpl` to support Helm variables and falls back to the default config if not set.