### PR TITLE
feat: Allow overriding Nginx configuration via values.yaml

### DIFF
--- a/charts/jumpserver/templates/web/configmap-web.yaml
+++ b/charts/jumpserver/templates/web/configmap-web.yaml
@@ -10,7 +10,14 @@ metadata:
     {{- include "jumpserver.labels" $ | nindent 4 }}
     {{- toYaml .labels | nindent 4 }}
 data:
-{{- $path := printf "%s/%s/%s" "configs" "jms-web" "default.conf" -}}
-{{- tpl (( $.Files.Glob $path ).AsConfig) $ | nindent 2 }}
+  default.conf: |
+    {{- $nginxConfigContent := "" }}
+    {{- if .nginxConfig }}
+      {{- $nginxConfigContent = .nginxConfig }}
+    {{- else }}
+      {{- $path := printf "%s/%s/%s" "configs" "jms-web" "default.conf" -}}
+      {{- $nginxConfigContent = $.Files.Get $path }}
+    {{- end }}
+    {{- tpl $nginxConfigContent $ | nindent 4 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Introduces `web.nginxConfig` in `values.yaml` to allow users to provide a custom `default.conf` for the jms-web service. The new value is rendered with `tpl` to support Helm variables and falls back to the default config if not set.